### PR TITLE
Add removeBindings method to ORMultiMap

### DIFF
--- a/src/main/scala/akka/contrib/datareplication/ORMultiMap.scala
+++ b/src/main/scala/akka/contrib/datareplication/ORMultiMap.scala
@@ -42,6 +42,18 @@ class ORMultiMap private (private[akka] val map: ORMap)
       ORMultiMap(map - key)
   }
 
+  def removeBindings(key: String, p: Any => Boolean)(implicit cluster: Cluster): ORMultiMap = {
+    val values = updateOrInit(
+      key,
+      values => (values /: values.value)((vs, e) => if (p(e)) vs - e else vs),
+      ORSet.empty
+    )
+    if (values.value.nonEmpty)
+      ORMultiMap(map + (key -> values))
+    else
+      ORMultiMap(map - key)
+  }
+
   private def updateOrInit(key: String, update: ORSet => ORSet, init: => ORSet): ORSet =
     map.get(key).asInstanceOf[Option[ORSet]] match {
       case Some(values) => update(values)


### PR DESCRIPTION
`removeBinding` removes exactly the given element, yet sometimes that's not what you want, e.g. because you don't have/know the exact element, but only some discriminating property. Therefore `removeBindings` is introduced which takes a predicate function determining which element(s) are to be removed.
