### PR TITLE
Add accept and parameterList directives

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,9 @@ name := "akka-contrib-extra"
 libraryDependencies ++= List(
   Library.akkaCluster,
   Library.akkaStream,
-  Library.akkaTestkit % "test",
-  Library.mockitoAll  % "test",
-  Library.scalaTest   % "test"
+  Library.akkaHttp,
+  Library.akkaTestkit     % "test",
+  Library.akkaHttpTestkit % "test",
+  Library.mockitoAll      % "test",
+  Library.scalaTest       % "test"
 )

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,3 +1,5 @@
+import bintray.Plugin.bintrayPublishSettings
+import bintray.Keys._
 import com.typesafe.sbt.SbtScalariform._
 import sbt._
 import sbt.Keys._
@@ -15,6 +17,7 @@ object Build extends AutoPlugin {
   override def projectSettings =
     scalariformSettings ++
     releaseSettings ++
+    bintrayPublishSettings ++
     List(
       // Core settings
       organization := "com.typesafe.akka",
@@ -29,15 +32,8 @@ object Build extends AutoPlugin {
       ),
       unmanagedSourceDirectories in Compile := List((scalaSource in Compile).value),
       unmanagedSourceDirectories in Test := List((scalaSource in Test).value),
-      publishTo := {
-        val typesafe = "http://private-repo.typesafe.com/typesafe"
-        val (name, u) =
-          if (isSnapshot.value)
-            "typesafe-snapshots" -> url(s"$typesafe/maven-snapshots/")
-          else
-            "typesafe-releases" -> url(s"$typesafe/maven-releases/")
-        Some(sbt.Resolver.url(name, u))
-      },
+      bintrayOrganization in bintray := Some("akka-contrib-extra"),
+      licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0")),
       // Scalariform settings
       ScalariformKeys.preferences := ScalariformKeys.preferences.value
         .setPreference(AlignSingleLineCaseStatements, true)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,9 +9,11 @@ object Version {
 }
 
 object Library {
-  val akkaCluster = "com.typesafe.akka" %% "akka-cluster"             % Version.akka
-  val akkaStream  = "com.typesafe.akka" %% "akka-stream-experimental" % Version.akkaStream
-  val akkaTestkit = "com.typesafe.akka" %% "akka-testkit"             % Version.akka
-  val mockitoAll  = "org.mockito"       %  "mockito-all"              % Version.mockito
-  val scalaTest   = "org.scalatest"     %% "scalatest"                % Version.scalaTest
+  val akkaCluster     = "com.typesafe.akka" %% "akka-cluster"                   % Version.akka
+  val akkaStream      = "com.typesafe.akka" %% "akka-stream-experimental"       % Version.akkaStream
+  val akkaHttp        = "com.typesafe.akka" %% "akka-http-experimental"         % Version.akkaStream
+  val akkaTestkit     = "com.typesafe.akka" %% "akka-testkit"                   % Version.akka
+  val akkaHttpTestkit = "com.typesafe.akka" %% "akka-http-testkit-experimental" % Version.akkaStream
+  val mockitoAll      = "org.mockito"       %  "mockito-all"                    % Version.mockito
+  val scalaTest       = "org.scalatest"     %% "scalatest"                      % Version.scalaTest
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("com.github.gseitz" % "sbt-release"     % "0.8.5")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("me.lessis"         % "bintray-sbt"     % "0.1.2")

--- a/src/main/scala/akka/contrib/http/Directives.scala
+++ b/src/main/scala/akka/contrib/http/Directives.scala
@@ -1,0 +1,60 @@
+package akka.contrib.http
+
+import akka.http.common.NameReceptacle
+import akka.http.model.MediaType
+import akka.http.model.headers.Accept
+import akka.http.server.{ Directive0, Directive1, MalformedQueryParamRejection, ValidationRejection }
+import akka.http.server.Directives._
+import akka.http.server.util.Tuple
+import akka.http.unmarshalling.{ FromStringUnmarshaller => FSU, Unmarshaller }
+import scala.util.{ Failure, Success }
+
+object Directives {
+
+  /**
+   * Continues to the inner route only if the `Accept` header
+   * contains the given media type.
+   */
+  def accept(mediaType: MediaType): Directive0 =
+    optionalHeaderValueByType[Accept](()).flatMap { accept =>
+      accept.flatMap(_.mediaRanges.collectFirst {
+        case range if range.matches(mediaType) => pass
+      }).getOrElse(reject)
+    }
+
+  /**
+   * Gets a list of parameters specified by a name and a type.
+   *
+   * Magnet pattern is used to keep the directive signature implicit
+   * parameters free, which makes usage of the directive cleaner.
+   */
+  def parameterList(pm: ParametersListMagnet): pm.Out = pm()
+
+  implicit def fromNameReceptacle[T](nr: NameReceptacle[T])(implicit fsu: FSU[T]) =
+    new ParametersListMagnet {
+      type Out = Directive1[List[T]]
+      def apply() =
+        parameterMultiMap.flatMap { multiMap =>
+          val parameterList = multiMap.getOrElse(nr.name, List.empty).map { value =>
+            onComplete(fsu(value)) flatMap {
+              case Success(x) => provide(x)
+              case Failure(x) => reject(MalformedQueryParamRejection(nr.name, x.getMessage, Option(x.getCause))).toDirective(Tuple.forTuple1[T])
+            }
+          }
+
+          Directive.sequence(parameterList)
+        }
+    }
+
+  sealed trait ParametersListMagnet {
+    type Out
+    def apply(): Out
+  }
+
+  object Directive {
+    def sequence[T](directives: List[Directive1[T]]) =
+      directives.foldLeft(provide(List.empty[T])) {
+        (dl, da) => dl.flatMap { l => da.flatMap(a => provide(l :+ a)) }
+      }
+  }
+}

--- a/src/test/scala/akka/contrib/http/DirectivesSpec.scala
+++ b/src/test/scala/akka/contrib/http/DirectivesSpec.scala
@@ -1,0 +1,59 @@
+package akka.contrib.http
+
+import org.scalatest.{ Inside, Matchers, WordSpec }
+import akka.http.testkit.TestFrameworkInterface.Scalatest
+import akka.http.testkit.RouteTest
+import akka.http.model.headers._
+import akka.http.model.MediaTypes._
+import akka.http.model.StatusCodes._
+import akka.http.model.{ HttpEntity, HttpResponse, MediaRange }
+import akka.http.server.Directives._
+import akka.http.server.{ MalformedQueryParamRejection, Route }
+
+class DirectivesSpec extends WordSpec with Matchers with Scalatest with RouteTest with Inside {
+
+  import Directives._
+
+  def echoComplete[T]: T ⇒ Route = { x ⇒ complete(x.toString) }
+
+  val Ok = HttpResponse()
+  val completeOk = complete(Ok)
+
+  "accept directive" should {
+
+    "pass to inner route if a matching accept header is present" in {
+      Get("/ping") ~> Accept(MediaRange(`text/plain`)) ~> accept(`text/plain`) { completeOk } ~> check {
+        response.status shouldBe OK
+      }
+    }
+
+    "reject if no requested accept header is present" in {
+      Get("/ping") ~> accept(`text/plain`) { completeOk } ~> check {
+        rejections shouldEqual Nil
+      }
+    }
+  }
+
+  "parameterList directive" should {
+
+    "provide a list of parameters to the inner route" in {
+      Get("/ping?p=1&p=2&p=3") ~> parameterList('p.as[Int]) { echoComplete } ~> check {
+        responseAs[String] shouldBe "List(3, 2, 1)"
+      }
+    }
+
+    "provide an empty list to the inner route if no parameters specified" in {
+      Get("/ping") ~> parameterList('p.as[Int]) { echoComplete } ~> check {
+        responseAs[String] shouldBe "List()"
+      }
+    }
+
+    "reject if parameters are of the wrong type" in {
+      Get("/ping?p=hello") ~> parameterList('p.as[Int]) { echoComplete } ~> check {
+        inside(rejection) { case MalformedQueryParamRejection("p", _, Some(e: NumberFormatException)) ⇒ }
+      }
+    }
+
+  }
+
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.5.0-SNAPSHOT"
+version in ThisBuild := "1.5.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.5.0"
+version in ThisBuild := "1.6.0-SNAPSHOT"


### PR DESCRIPTION
As I am not able to release to `typesafe-releases` repo and this is a public project, I configured release to bintray. Now every member of [akka-contrib-extra](https://bintray.com/akka-contrib-extra) bintray organization can cut a release of this library. Release process is still the same using `sbt-release` plugin.