### PR TITLE
Upgrade to akka-streams 1.0-M4

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Version {
   val akka                = "2.3.9"
-  val akkaStream          = "1.0-M3"
+  val akkaStream          = "1.0-M4"
   val mockito             = "1.9.5"
   val scala               = "2.11.5"
   val scalaTest           = "2.2.3"

--- a/src/main/scala/akka/contrib/stream/SourceInputStream.scala
+++ b/src/main/scala/akka/contrib/stream/SourceInputStream.scala
@@ -194,7 +194,7 @@ private object SourceInputStream {
 /**
  * Reads from a source in a blocking manner and in accordance with the JDK InputStream API.
  */
-class SourceInputStream(source: Source[ByteString], timeout: FiniteDuration)(implicit factory: ActorRefFactory)
+class SourceInputStream(source: Source[ByteString, Unit], timeout: FiniteDuration)(implicit factory: ActorRefFactory)
     extends InputStream {
 
   import SourceInputStream._


### PR DESCRIPTION
Using `merge.in(...)` instead of `merge` because of https://github.com/akka/akka/issues/16997