### PR TITLE
+ improvements in reconnection utilities

### DIFF
--- a/src/main/scala/akka/contrib/stream/pattern/reconnect/ReconnectingStreamHttp.scala
+++ b/src/main/scala/akka/contrib/stream/pattern/reconnect/ReconnectingStreamHttp.scala
@@ -3,17 +3,22 @@
  */
 package akka.contrib.stream.pattern.reconnect
 
+import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicLong
+
 import akka.actor._
 import akka.contrib.stream.pattern.reconnect.Reconnector._
+import akka.event.LoggingAdapter
 import akka.http.Http
 import akka.http.Http.OutgoingConnection
 import akka.http.engine.client.ClientConnectionSettings
 import akka.http.model.{ HttpRequest, HttpResponse }
+import akka.io.Inet
 import akka.pattern.ask
 import akka.stream.FlowMaterializer
 import akka.stream.scaladsl.Flow
-import akka.util.Timeout
-import java.net.InetSocketAddress
+
+import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 import scala.language.postfixOps
@@ -30,7 +35,10 @@ object ReconnectingStreamHttp {
       address: InetSocketAddress,
       interval: FiniteDuration,
       retriesRemaining: Long,
+      localAddress: Option[InetSocketAddress],
+      options: immutable.Traversable[Inet.SocketOption],
       settings: Option[ClientConnectionSettings],
+      log: LoggingAdapter,
       onConnection: (HttpConnected => Unit)) extends ReconnectionData[HttpConnected] {
     def decrementRetryCounter: HttpReconnectionData = copy(retriesRemaining = retriesRemaining - 1)
   }
@@ -38,12 +46,11 @@ object ReconnectingStreamHttp {
   /**
    * Offered as callback argument when a connection is established, may be useful to extract new materialized values etc.
    *
-   * @param flow representing the http connection
-   * @param reconnectionCancellable used to stop this connection from being re-established (when you want to cleanly close it)
+   * @param flow representing the http connection (with applied reconnection logic)
+   * @param cancelReconnections used to stop this connection from being re-established (when you want to cleanly close it)
    */
-  final case class HttpConnected(flow: Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]], reconnectionCancellable: Cancellable)
+  final case class HttpConnected(flow: Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]], cancelReconnections: () => Unit)
     extends ConnectionStatus
-
   /**
    * Creates an actor monitored resilient connection which will be reconnected in given intervals in case of failure.
    *
@@ -54,23 +61,30 @@ object ReconnectingStreamHttp {
    */
   // format: OFF
   def outgoingConnection(host: String,
-                         port: Int, reconnectInterval: FiniteDuration,
-                         settings: Option[ClientConnectionSettings],
-                         maxRetries: Int = Int.MaxValue)
+                         reconnectInterval: FiniteDuration,
+                         maxRetries: Int = Int.MaxValue,
+                         port: Int = 80,
+                         localAddress: Option[InetSocketAddress] = None,
+                         options: immutable.Traversable[Inet.SocketOption] = Nil,
+                         settings: Option[ClientConnectionSettings] = None,
+                         log: Option[LoggingAdapter] = None)
                         (onConnection: HttpConnected => Unit)
                         (implicit sys: ActorSystem, mat: FlowMaterializer): Future[ConnectionStatus] = {
     // format: ON
     require(maxRetries >= 0, "maxRetries must be >= 0")
     import sys.dispatcher
+    val data = HttpReconnectionData(new InetSocketAddress(host, port), reconnectInterval, maxRetries, localAddress, options, settings, log.getOrElse(sys.log), onConnection)
+    implicit val timeout = Reconnector.connectionTimeout(sys)
 
-    val data = HttpReconnectionData(new InetSocketAddress(host, port), reconnectInterval, maxRetries, settings, onConnection)
-    implicit val timeout = Timeout(data.interval * maxRetries)
-
-    val reconnector = sys.actorOf(Props(new HttpReconnector(data, mat)))
+    val reconnector = sys.actorOf(Props(new HttpReconnector(data, mat)), nextName())
     (reconnector ? InitialConnect).mapTo[ConnectionStatus].recover {
       case f: Throwable => InitialConnectionFailed(data.retriesRemaining, reconnector)
     }
   }
+
+  private val counter = new AtomicLong()
+  private def nextName(): String =
+    s"reconnector-http-${counter.incrementAndGet()}" // TODO include host/port (needs encoding of host name)
 
   private class HttpReconnector(initialData: HttpReconnectionData, implicit val mat: FlowMaterializer)
       extends Reconnector[HttpConnected, HttpReconnectionData](initialData) {
@@ -79,9 +93,17 @@ object ReconnectingStreamHttp {
     override def connect(data: HttpReconnectionData): HttpConnected = {
       val host = data.address.getHostName
       val port = data.address.getPort
-      val connection = Http().outgoingConnection(host, port, settings = initialData.settings)
 
-      HttpConnected(connection, StopSelf)
+      val connection = Http().outgoingConnection(
+        host, port,
+        settings = initialData.settings,
+        localAddress = initialData.localAddress,
+        options = initialData.options,
+        log = initialData.log)
+
+      val reconnectingConnection = connection.transform(() => new ReconnectStage(data))
+
+      HttpConnected(reconnectingConnection, StopSelf)
     }
   }
 }

--- a/src/main/scala/akka/contrib/stream/pattern/reconnect/ReconnectingStreamTcp.scala
+++ b/src/main/scala/akka/contrib/stream/pattern/reconnect/ReconnectingStreamTcp.scala
@@ -4,17 +4,19 @@
 package akka.contrib.stream.pattern.reconnect
 
 import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicLong
 
-import akka.actor.{ ActorSystem, Cancellable, Props }
+import akka.actor.{ ActorSystem, Props }
 import akka.contrib.stream.pattern.reconnect.Reconnector._
+import akka.io.Inet.SocketOption
 import akka.pattern.ask
 import akka.stream.FlowMaterializer
-import akka.stream.scaladsl.{ StreamTcp, Flow }
-import akka.stream.stage.{ Context, Directive, PushStage, TerminationDirective }
-import akka.util.{ ByteString, Timeout }
+import akka.stream.scaladsl.{ Flow, StreamTcp }
+import akka.util.ByteString
 
-import scala.concurrent.{ Promise, Future }
-import scala.concurrent.duration.FiniteDuration
+import scala.collection.immutable
+import scala.concurrent.Future
+import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.language.postfixOps
 
 /**
@@ -25,22 +27,27 @@ object ReconnectingStreamTcp {
   /**
    * Used for tracking reconnection state (counters) of connections.
    */
-  case class TcpReconnectionData[M](
+  case class TcpReconnectionData(
       address: InetSocketAddress,
-      handler: Flow[ByteString, ByteString, M],
       interval: FiniteDuration,
       retriesRemaining: Long,
-      onConnection: (ConnectionStatus => Unit)) extends ReconnectionData[TcpConnected[M]] {
+
+      localAddress: Option[InetSocketAddress],
+      options: immutable.Traversable[SocketOption],
+      connectTimeout: Duration,
+      idleTimeout: Duration,
+
+      onConnection: (TcpConnected => Unit)) extends ReconnectionData[TcpConnected] {
     override def decrementRetryCounter = copy(retriesRemaining = retriesRemaining - 1)
   }
 
   /**
    * Offered as callback argument when a connection is established, may be useful to extract new materialized values etc.
    *
-   * @param materialized the materialized values of this streams incarnation (different each time the stream reconnects)
-   * @param reconnectionCancellable used to stop this connection from being re-established (when you want to cleanly close it)
+   * @param flow representing the Tcp connection (with applied reconnection logic)
+   * @param cancelReconnections used to stop this connection from being re-established (when you want to cleanly close it)
    */
-  final case class TcpConnected[M](materialized: M, reconnectionCancellable: Cancellable) extends ConnectionStatus
+  final case class TcpConnected(flow: Flow[ByteString, ByteString, Future[StreamTcp.OutgoingConnection]], cancelReconnections: () => Unit) extends ConnectionStatus
 
   /**
    * Creates an actor monitored resilient connection which will be reconnected in given intervals in case of failure.
@@ -52,33 +59,42 @@ object ReconnectingStreamTcp {
    *
    */
   // format: OFF
-  def outgoingConnection[M](address: InetSocketAddress, handleWith: Flow[ByteString, ByteString, M], reconnectInterval: FiniteDuration, maxRetries: Long = Long.MaxValue)
-                           (onConnection: (ConnectionStatus => Unit))
-                           (implicit sys: ActorSystem, mat: FlowMaterializer): Future[ConnectionStatus] = {
+  def outgoingConnection(address: InetSocketAddress,
+                         reconnectInterval: FiniteDuration,
+                         maxRetries: Long = Long.MaxValue,
+                         localAddress: Option[InetSocketAddress] = None,
+                         options: immutable.Traversable[SocketOption] = Nil,
+                         connectTimeout: Duration = Duration.Inf,
+                         idleTimeout: Duration = Duration.Inf)
+                        (onConnection: (TcpConnected => Unit))
+                        (implicit sys: ActorSystem, mat: FlowMaterializer): Future[ConnectionStatus] = {
     // format: ON
     require(maxRetries >= 0, "maxRetries must be >= 0")
     import sys.dispatcher
 
-    val data = TcpReconnectionData[M](address, handleWith, reconnectInterval, maxRetries, onConnection)
-    implicit val timeout = Timeout(data.interval * maxRetries)
+    val data = TcpReconnectionData(address, reconnectInterval, maxRetries, localAddress, options, connectTimeout, idleTimeout, onConnection)
+    implicit val timeout = Reconnector.connectionTimeout(sys)
 
-    val reconnector = sys.actorOf(Props(new TcpReconnector(data, mat)))
+    val reconnector = sys.actorOf(Props(new TcpReconnector(data, mat)), nextName())
     (reconnector ? InitialConnect).mapTo[ConnectionStatus].recover {
       case f: Throwable => InitialConnectionFailed(data.retriesRemaining, reconnector)
     }
   }
 
-  private class TcpReconnector[M](initialData: TcpReconnectionData[M], implicit val mat: FlowMaterializer)
-      extends Reconnector[TcpConnected[M], ReconnectionData[TcpConnected[M]]](initialData) {
+  private val counter = new AtomicLong()
+  private def nextName(): String =
+    s"reconnector-tcp-${counter.incrementAndGet()}" // TODO include host/port (needs encoding of host name)
+
+  private class TcpReconnector(initialData: TcpReconnectionData, implicit val mat: FlowMaterializer)
+      extends Reconnector[TcpConnected, TcpReconnectionData](initialData) {
 
     import context.system
 
-    override def connect(data: ReconnectionData[TcpConnected[M]]): TcpConnected[M] = {
-      val connection = StreamTcp().outgoingConnection(data.address, connectTimeout = data.interval) // TODO sure?
-      val handlerWithReconnection = initialData.handler.transform(() => new ReconnectStage(data))
-      val (_, materialized) = connection.join(handlerWithReconnection).run()
+    override def connect(data: TcpReconnectionData): TcpConnected = {
+      val connection = StreamTcp().outgoingConnection(data.address, data.localAddress, data.options, data.connectTimeout, data.idleTimeout)
+      val reconnecting = connection.transform(() => new ReconnectStage(data))
 
-      TcpConnected(materialized, StopSelf)
+      TcpConnected(reconnecting, StopSelf)
     }
 
   }

--- a/src/main/scala/akka/contrib/stream/pattern/reconnect/package.scala
+++ b/src/main/scala/akka/contrib/stream/pattern/reconnect/package.scala
@@ -1,0 +1,15 @@
+package akka.contrib.stream.pattern
+
+import akka.http.Http
+import akka.stream.scaladsl.StreamTcp
+
+package object reconnect {
+
+  implicit final class ReconnectHttp(val h: Http.type) extends AnyVal {
+    def reconnecting = ReconnectingStreamHttp
+  }
+
+  implicit final class ReconnectTcp(val h: StreamTcp.type) extends AnyVal {
+    def reconnecting = ReconnectingStreamTcp
+  }
+}

--- a/src/test/scala/akka/contrib/stream/pattern/reconnect/ReconnectingStreamHttpSpec.scala
+++ b/src/test/scala/akka/contrib/stream/pattern/reconnect/ReconnectingStreamHttpSpec.scala
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.contrib.stream.pattern.reconnect
+
+import akka.actor.ActorSystem
+import akka.event.Logging
+import akka.http.Http
+import akka.stream.ActorFlowMaterializer
+import akka.stream.scaladsl.{ Sink, Source }
+import akka.testkit.{ TestKitExtension, TestProbe }
+import akka.util.Timeout
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
+
+import scala.languageFeature.postfixOps
+import scala.util.control.NoStackTrace
+
+class ReconnectingStreamHttpSpec extends WordSpecLike with Matchers with BeforeAndAfterAll with ScalaFutures {
+
+  import scala.concurrent.duration._
+
+  implicit val system = ActorSystem("test")
+
+  implicit val timeout: Timeout = TestKitExtension(system).DefaultTimeout
+
+  override protected def afterAll(): Unit = {
+    system.shutdown()
+    system.awaitTermination(timeout.duration)
+  }
+
+  val Localhost = "127.0.0.1"
+
+  implicit val mat = ActorFlowMaterializer()
+
+  "ReconnectingStreamHttp" must {
+
+    "keep trying to connect" in {
+      val p = TestProbe()
+
+      val reconnectInterval = 200 millis
+      val maxRetries = 4
+
+      system.eventStream.subscribe(p.ref, classOf[Logging.Info])
+
+      // notice how we keep the APIs similar:
+      // val singleConnection = Http().outgoingConnection(Localhost)
+      val initial = Http.reconnecting.outgoingConnection(Localhost, reconnectInterval, maxRetries) { connected =>
+        Source.failed(new TestException("Acting as if unable to connect!"))
+          .via(connected.flow)
+          .runWith(Sink.ignore())
+      }
+
+      p.expectMsgType[Logging.Info].message.toString should startWith("Opening initial connection to: /127.0.0.1:80")
+      (1 to maxRetries) foreach { _ =>
+        p.expectMsgType[Logging.Info].message.toString should startWith("Connection to localhost/127.0.0.1:80 was closed abruptly, reconnecting!")
+        p.expectMsgType[Logging.Info].message.toString should startWith("Reconnecting to localhost/127.0.0.1:80")
+      }
+
+      p.expectNoMsg(2.seconds)
+
+      initial.futureValue // it must be completed
+    }
+  }
+
+  class TestException(msg: String) extends Exception(msg) with NoStackTrace
+}

--- a/src/test/scala/akka/contrib/stream/pattern/reconnect/ReconnectingStreamTcpSpec.scala
+++ b/src/test/scala/akka/contrib/stream/pattern/reconnect/ReconnectingStreamTcpSpec.scala
@@ -1,24 +1,23 @@
 /**
  * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
  */
-
 package akka.contrib.stream.pattern.reconnect
 
 import java.net.InetSocketAddress
 
 import akka.actor.ActorSystem
 import akka.contrib.stream.pattern.reconnect.ReconnectingStreamTcp.TcpConnected
-import akka.contrib.stream.pattern.reconnect.Reconnector.{ InitialConnectionFailed, ConnectionStatus }
 import akka.stream.ActorFlowMaterializer
-import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.{ Sink, Source, StreamTcp }
 import akka.testkit.{ TestKitExtension, TestProbe }
-import akka.util.{ ByteString, Timeout }
+import akka.util.Timeout
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
 
 import scala.languageFeature.postfixOps
-import scala.util.{ Failure, Success }
+import scala.util.control.NoStackTrace
 
-class ReconnectingStreamTcpTest extends WordSpecLike with Matchers with BeforeAndAfterAll {
+class ReconnectingStreamTcpSpec extends WordSpecLike with Matchers with BeforeAndAfterAll with ScalaFutures {
 
   import scala.concurrent.duration._
 
@@ -41,24 +40,28 @@ class ReconnectingStreamTcpTest extends WordSpecLike with Matchers with BeforeAn
     "keep trying to connect" in {
       val p = TestProbe()
 
-      val handler = Flow[ByteString]
-
       val reconnectInterval = 200 millis
       val initialConnection = 1
       val maxRetries = 4
 
-      ReconnectingStreamTcp.outgoingConnection[Unit](InSpaceNoOneCanHearYouConnect, handler, reconnectInterval, maxRetries)(p.ref ! _)
+      // notice how we keep the APIs similar:
+      // val singleConnection = StreamTcp().outgoingConnection(InSpaceNoOneCanHearYouConnect)
+      val initial = StreamTcp.reconnecting.outgoingConnection(InSpaceNoOneCanHearYouConnect, reconnectInterval, maxRetries) { connected =>
+        Source.failed(new TestException("Acting as if unable to connect!"))
+          .via(connected.flow)
+          .runWith(Sink.ignore())
+        p.ref ! connected
+      }
 
-      (1 to (initialConnection + maxRetries)) foreach { _ => p.expectMsgType[TcpConnected[_]] }
+      (1 to (initialConnection + maxRetries)) foreach { _ => p.expectMsgType[TcpConnected] }
 
       p.expectNoMsg(2.seconds)
+      initial.futureValue // must be completed
     }
   }
 
   "allow multiple connections with their own retries to the same address" in {
     val p1, p2 = TestProbe()
-
-    val handler = Flow[ByteString]
 
     val host1 = new InetSocketAddress("127.0.0.1", 1)
     val host2 = new InetSocketAddress("127.0.0.1", 2)
@@ -68,11 +71,21 @@ class ReconnectingStreamTcpTest extends WordSpecLike with Matchers with BeforeAn
     val maxRetries1 = 2
     val maxRetries2 = 5
 
-    ReconnectingStreamTcp.outgoingConnection[Unit](host1, handler, reconnectInterval, maxRetries1)(p1.ref ! _)
-    ReconnectingStreamTcp.outgoingConnection[Unit](host2, handler, reconnectInterval, maxRetries2)(p2.ref ! _)
+    StreamTcp.reconnecting.outgoingConnection(host1, reconnectInterval, maxRetries1) { connected =>
+      Source.failed(new TestException("Acting as if unable to connect!"))
+        .via(connected.flow)
+        .runWith(Sink.ignore())
+      p1.ref ! connected
+    }
+    StreamTcp.reconnecting.outgoingConnection(host2, reconnectInterval, maxRetries2) { connected =>
+      Source.failed(new TestException("Acting as if unable to connect!"))
+        .via(connected.flow)
+        .runWith(Sink.ignore())
+      p2.ref ! connected
+    }
 
-    (1 to (initialConnection + maxRetries1)) foreach { _ => p1.expectMsgType[TcpConnected[_]] }
-    (1 to (initialConnection + maxRetries2)) foreach { _ => p2.expectMsgType[TcpConnected[_]] }
+    (1 to (initialConnection + maxRetries1)) foreach { _ => p1.expectMsgType[TcpConnected] }
+    (1 to (initialConnection + maxRetries2)) foreach { _ => p2.expectMsgType[TcpConnected] }
 
     p1.expectNoMsg(1.second)
     p2.expectNoMsg(1.second)
@@ -82,4 +95,5 @@ class ReconnectingStreamTcpTest extends WordSpecLike with Matchers with BeforeAn
 
   "reconnect if the connection breaks after being established" in pending // TODO implement a proper test for this
 
+  class TestException(msg: String) extends Exception(msg) with NoStackTrace
 }


### PR DESCRIPTION
* reconnection APIs look now more like their normal counterparts - with the onConnect being given a new flow for each connection, they should materialize it
* http now actually reconnects; added tests as well
* reconnecting tcp / http delegate *all* params that may be passed into the normal outgoingConnection method. 
* better names for reconnection actors - still top level though, would be nice to have them move under a parent at some point.
* resolves https://github.com/typesafehub/akka-contrib-extra/issues/21