### PR TITLE
WIP - DON'T MERGE: Upgrade to akka-stream/http 1.0-M5

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,8 @@ import sbt._
 
 object Version {
   val akka                = "2.3.9"
-  val akkaStream          = "1.0-M4"
+  val akkaHttp          = "1.0-M5"
+  val akkaStream          = "1.0-M5"
   val mockito             = "1.9.5"
   val scala               = "2.11.6"
   val scalaTest           = "2.2.4"
@@ -10,8 +11,8 @@ object Version {
 
 object Library {
   val akkaCluster     = "com.typesafe.akka" %% "akka-cluster"                   % Version.akka
+  val akkaHttp        = "com.typesafe.akka" %% "akka-http-experimental"         % Version.akkaHttp
   val akkaStream      = "com.typesafe.akka" %% "akka-stream-experimental"       % Version.akkaStream
-  val akkaHttp        = "com.typesafe.akka" %% "akka-http-experimental"         % Version.akkaStream
   val akkaTestkit     = "com.typesafe.akka" %% "akka-testkit"                   % Version.akka
   val akkaHttpTestkit = "com.typesafe.akka" %% "akka-http-testkit-experimental" % Version.akkaStream
   val mockitoAll      = "org.mockito"       %  "mockito-all"                    % Version.mockito

--- a/src/test/scala/akka/contrib/stream/pattern/reconnect/ReconnectingStreamHttpSpec.scala
+++ b/src/test/scala/akka/contrib/stream/pattern/reconnect/ReconnectingStreamHttpSpec.scala
@@ -49,7 +49,7 @@ class ReconnectingStreamHttpSpec extends WordSpecLike with Matchers with BeforeA
       val initial = Http.reconnecting.outgoingConnection(Localhost, reconnectInterval, maxRetries) { connected =>
         Source.failed(new TestException("Acting as if unable to connect!"))
           .via(connected.flow)
-          .runWith(Sink.ignore())
+          .runWith(Sink.ignore)
       }
 
       p.expectMsgType[Logging.Info].message.toString should startWith("Opening initial connection to: /127.0.0.1:80")

--- a/src/test/scala/akka/contrib/stream/pattern/reconnect/ReconnectingStreamTcpSpec.scala
+++ b/src/test/scala/akka/contrib/stream/pattern/reconnect/ReconnectingStreamTcpSpec.scala
@@ -49,7 +49,7 @@ class ReconnectingStreamTcpSpec extends WordSpecLike with Matchers with BeforeAn
       val initial = StreamTcp.reconnecting.outgoingConnection(InSpaceNoOneCanHearYouConnect, reconnectInterval, maxRetries) { connected =>
         Source.failed(new TestException("Acting as if unable to connect!"))
           .via(connected.flow)
-          .runWith(Sink.ignore())
+          .runWith(Sink.ignore)
         p.ref ! connected
       }
 
@@ -74,13 +74,13 @@ class ReconnectingStreamTcpSpec extends WordSpecLike with Matchers with BeforeAn
     StreamTcp.reconnecting.outgoingConnection(host1, reconnectInterval, maxRetries1) { connected =>
       Source.failed(new TestException("Acting as if unable to connect!"))
         .via(connected.flow)
-        .runWith(Sink.ignore())
+        .runWith(Sink.ignore)
       p1.ref ! connected
     }
     StreamTcp.reconnecting.outgoingConnection(host2, reconnectInterval, maxRetries2) { connected =>
       Source.failed(new TestException("Acting as if unable to connect!"))
         .via(connected.flow)
-        .runWith(Sink.ignore())
+        .runWith(Sink.ignore)
       p2.ref ! connected
     }
 


### PR DESCRIPTION
`ReconnectingStreamHttpSpec` fails now, succeeded under M4. I wonder whether we need that feature at all, since we found an alternative approach to reconnecting for ConductR. I'd rather not include an unused feature, because unused is sort of untested.

As I'll be on vacation next week, I'll leave this one for you ...