### PR TITLE
Added NoSerializationVerificationNeeded marker

### DIFF
--- a/src/test/scala/akka/contrib/process/package.scala
+++ b/src/test/scala/akka/contrib/process/package.scala
@@ -11,8 +11,13 @@ package object process {
   val testConfig: Config = {
     def testConfig: Config =
       ConfigFactory parseString """|akka {
-                                   |  loglevel        = debug
-                                   |  actor.debug.fsm = false
+                                   |  loglevel = debug
+                                   |  actor {
+                                   |    debug.fsm = false
+                                   |    #Commented out for now given: https://github.com/akka/akka/issues/17393
+                                   |    #serialize-messages = on
+                                   |  }
+                                   |
                                    |}""".stripMargin
     ConfigFactory.defaultOverrides() withFallback testConfig withFallback ConfigFactory.load()
   }


### PR DESCRIPTION
In addition the blocking process actor now ensures that its messages may only be sent to its parent, and not any other type of actor. This is because the actor publishers sent as part of the start message are not serialisable.

Contributes toward: https://github.com/typesafehub/conductr/issues/512