### PR TITLE
A logging Subscriber 

### DIFF
--- a/src/main/scala/akka/contrib/stream/LoggingSubscriber.scala
+++ b/src/main/scala/akka/contrib/stream/LoggingSubscriber.scala
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.contrib.stream
+
+import akka.actor.{ ActorLogging, Props }
+import akka.event.Logging
+import akka.stream.actor.ActorSubscriberMessage.{ OnNext, OnError, OnComplete }
+import akka.stream.actor.{ OneByOneRequestStrategy, RequestStrategy, ActorSubscriber }
+import akka.util.ByteString
+
+import scala.annotation.tailrec
+
+/**
+ * Companion for [[LoggingSubscriber]] – defines a Props factory.
+ */
+object LoggingSubscriber {
+  val OneMegaByte: Int = 1024 * 1024
+  /**
+   * Create Props for an [[LoggingSubscriber]].
+   *
+   * @param level the `akka.event.Logging.LogLevel` used for logging the received strings
+   * @param separator the `String` representing the separator, defaults to \n
+   * @param maximumLineBytes an `int` used to limit the maximum allowed length of a line (in number of bytes),
+   *                         defaults to 1MB. Over this limit the line is logged as is and the buffer is reset.
+   * @return Props for an [[LoggingSubscriber]]
+   */
+  def props(level: Logging.LogLevel, separator: String = "\n", maximumLineBytes: Int = OneMegaByte): Props =
+    Props(new LoggingSubscriber(level, separator, maximumLineBytes))
+}
+
+/**
+ * Subscribes to a reactive stream of ByteStrings, parses lines and logs them at the requested level
+ *
+ * @param level the `akka.event.Logging.LogLevel` used for logging the received strings
+ * @param separator the `String` representing the separator
+ * @param maximumLineBytes an `int` used to limit the maximum allowed length of a line (in number of bytes).
+ *                         Over this limit the line is logged as is and the buffer is reset.
+ */
+class LoggingSubscriber(level: Logging.LogLevel, separator: String, maximumLineBytes: Int)
+    extends ActorSubscriber
+    with ActorLogging {
+
+  override protected def requestStrategy: RequestStrategy =
+    OneByOneRequestStrategy
+
+  private val separatorBytes = ByteString(separator)
+  private val firstSeparatorByte = separatorBytes.head
+  private var buffer = ByteString.empty
+  private var nextPossibleMatch = 0
+
+  override def receive: Receive = {
+    case OnNext(element: ByteString) => onNext(element)
+    case OnComplete                  => onComplete()
+    case OnError(cause)              => onError(cause)
+  }
+
+  private def onNext(element: ByteString): Unit = {
+    buffer ++= element
+    doParse(Vector.empty).foreach(line => log.log(level, line))
+    if (buffer.size > maximumLineBytes) {
+      val line = buffer.utf8String
+      log.log(level, line)
+      buffer = ByteString.empty
+    }
+  }
+
+  @tailrec
+  private def doParse(parsedLinesSoFar: Vector[String]): Vector[String] = {
+    val possibleMatchPos = buffer.indexOf(firstSeparatorByte, from = nextPossibleMatch)
+    if (possibleMatchPos == -1) {
+      // No matching character, we need to accumulate more bytes into the buffer
+      nextPossibleMatch = buffer.size
+      parsedLinesSoFar
+    } else {
+      if (possibleMatchPos + separatorBytes.size > buffer.size) {
+        // We have found a possible match (we found the first character of the terminator
+        // sequence) but we don't have yet enough bytes. We remember the position to
+        // retry from next time.
+        nextPossibleMatch = possibleMatchPos
+        parsedLinesSoFar
+      } else {
+        if (buffer.slice(possibleMatchPos, possibleMatchPos + separatorBytes.size)
+          == separatorBytes) {
+          // Found a match
+          val parsedLine = buffer.slice(0, possibleMatchPos).utf8String
+          buffer = buffer.drop(possibleMatchPos + separatorBytes.size)
+          nextPossibleMatch -= possibleMatchPos + separatorBytes.size
+          doParse(parsedLinesSoFar :+ parsedLine)
+        } else {
+          nextPossibleMatch += 1
+          doParse(parsedLinesSoFar)
+        }
+      }
+    }
+
+  }
+
+  private def onComplete(): Unit =
+    context.stop(self)
+
+  private def onError(cause: Throwable): Unit = {
+    log.error(cause, "Stopping because of upstream error!")
+    context.stop(self)
+  }
+}

--- a/src/test/scala/akka/contrib/stream/LoggingSubscriberSpec.scala
+++ b/src/test/scala/akka/contrib/stream/LoggingSubscriberSpec.scala
@@ -1,0 +1,123 @@
+/**
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.contrib.stream
+
+import akka.actor.ActorSystem
+import akka.event.Logging
+import akka.event.Logging.LogEvent
+import akka.stream.actor.ActorSubscriberMessage.{ OnError, OnComplete, OnNext }
+import akka.testkit.TestProbe
+import akka.util.ByteString
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
+
+class LoggingSubscriberSpec extends WordSpec with Matchers with BeforeAndAfterAll {
+  implicit val system = ActorSystem("test", testConfig)
+
+  "Sending ActorSubscriber.OnNext with a ByteString representing a single line to a LoggingSubscriber" should {
+    "result in writing the single line to the logs" in {
+      // Given
+      val logLine: String = "first line"
+      val loggingSubscriber = system.actorOf(LoggingSubscriber.props(Logging.InfoLevel))
+      val logSource = loggingSubscriber.path.toString
+      val probe: TestProbe = TestProbe()
+      system.eventStream.subscribe(probe.ref, classOf[LogEvent])
+
+      //When
+      loggingSubscriber ! OnNext(ByteString(logLine + "\n"))
+
+      // Then
+      probe.fishForMessage() {
+        case loggedLine @ Logging.Info(`logSource`, clazz, _) if clazz == classOf[LoggingSubscriber] => true
+      } shouldEqual Logging.Info(logSource, classOf[LoggingSubscriber], logLine)
+    }
+  }
+
+  "Sending ActorSubscriber.OnComplete to an an LoggingSubscriber" should {
+    "result in the stopping the LoggingSubscriber" in {
+      val probe = TestProbe()
+      val loggingSubscriber = system.actorOf(LoggingSubscriber.props(Logging.InfoLevel))
+      probe.watch(loggingSubscriber)
+      loggingSubscriber ! OnComplete
+      probe.expectTerminated(loggingSubscriber)
+    }
+  }
+
+  "Sending ActorSubscriber.OnError to an an OutputStreamSubscriber" should {
+    "result in closing the OutputStream" in {
+      val loggingSubscriber = system.actorOf(LoggingSubscriber.props(Logging.InfoLevel))
+      loggingSubscriber ! OnError(new Exception("By purpose!"))
+    }
+  }
+
+  "Sending ActorSubscriber.OnNext with a ByteString representing two lines to a LoggingSubscriber" should {
+    "result in writing both lines to the logs in separate messages" in {
+      // Given
+      val firstLine: String = "first line"
+      val secondLine: String = "second line"
+      val loggingSubscriber = system.actorOf(LoggingSubscriber.props(Logging.InfoLevel))
+      val logSource = loggingSubscriber.path.toString
+      val probe: TestProbe = TestProbe()
+      system.eventStream.subscribe(probe.ref, classOf[LogEvent])
+
+      //When
+      loggingSubscriber ! OnNext(ByteString(firstLine + "\n" + secondLine + "\n"))
+
+      // Then
+      probe.fishForMessage() {
+        case loggedLine @ Logging.Info(`logSource`, clazz, _) if clazz == classOf[LoggingSubscriber] => true
+      } shouldEqual Logging.Info(logSource, classOf[LoggingSubscriber], firstLine)
+
+      probe.fishForMessage() {
+        case loggedLine @ Logging.Info(`logSource`, clazz, _) if clazz == classOf[LoggingSubscriber] => true
+      } shouldEqual Logging.Info(logSource, classOf[LoggingSubscriber], secondLine)
+    }
+  }
+  "Sending ActorSubscriber.OnNext with two ByteStrings representing a line to a LoggingSubscriber" should {
+    "result in writing the line to the logs in a signle messages" in {
+      // Given
+      val first: String = "first"
+      val second: String = " line"
+      val loggingSubscriber = system.actorOf(LoggingSubscriber.props(Logging.InfoLevel))
+      val logSource = loggingSubscriber.path.toString
+
+      val probe: TestProbe = TestProbe()
+      system.eventStream.subscribe(probe.ref, classOf[LogEvent])
+
+      //When
+      loggingSubscriber ! OnNext(ByteString(first))
+      loggingSubscriber ! OnNext(ByteString(second + "\n"))
+
+      // Then
+      probe.fishForMessage() {
+        case loggedLine @ Logging.Info(`logSource`, clazz, _) if clazz == classOf[LoggingSubscriber] => true
+      } shouldEqual Logging.Info(logSource, classOf[LoggingSubscriber], "first line")
+    }
+  }
+  "Sending ActorSubscriber.OnNext with three ByteStrings representing a line longer than maximumLineLength to a LoggingSubscriber" should {
+    "result in writing the line to the logs in separate messages" in {
+      // Given
+      val first: String = "first"
+      val line: String = " line"
+      val loggingSubscriber = system.actorOf(LoggingSubscriber.props(Logging.InfoLevel, maximumLineBytes = 1))
+      val logSource = loggingSubscriber.path.toString
+
+      val probe: TestProbe = TestProbe()
+      system.eventStream.subscribe(probe.ref, classOf[LogEvent])
+
+      //When
+      loggingSubscriber ! OnNext(ByteString(first))
+      loggingSubscriber ! OnNext(ByteString(line))
+      loggingSubscriber ! OnNext(ByteString("\\"))
+
+      // Then
+      probe.fishForMessage() {
+        case loggedLine @ Logging.Info(`logSource`, clazz, _) if clazz == classOf[LoggingSubscriber] => true
+      } shouldEqual Logging.Info(logSource, classOf[LoggingSubscriber], first)
+
+      probe.fishForMessage() {
+        case loggedLine @ Logging.Info(`logSource`, clazz, _) if clazz == classOf[LoggingSubscriber] => true
+      } shouldEqual Logging.Info(logSource, classOf[LoggingSubscriber], line)
+    }
+  }
+}


### PR DESCRIPTION
It parses lines out of a Stream[ByteString] then logs them to the enclosing ActorSystem logging bus.

Lines are defined by a separator ("\n" by default), bytes are accumulated until a separator is found or the maximumLineLength is exceeded (1MByte by default)

I wrote this to be able to centralize logs from processes spawned with akka.contrib.process.BlockingProcess to the application log file (in my case a webdriver based app)