### PR TITLE
Akka streams 2 upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ scala:
 - 2.10.5
 - 2.11.6
 jdk:
-- openjdk6
 - oraclejdk7
 - oraclejdk8
 script: sbt test

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,8 +2,8 @@ import sbt._
 
 object Version {
   val akka       = "2.3.12"
-  val akkaHttp   = "1.0"
-  val akkaStream = "1.0"
+  val akkaHttp   = "2.0-M2"
+  val akkaStream = "2.0-M2"
   val mockito    = "1.9.5"
   val scala      = "2.11.7"
   val scalaTest  = "2.2.4"

--- a/src/main/scala/akka/contrib/http/Directives.scala
+++ b/src/main/scala/akka/contrib/http/Directives.scala
@@ -7,6 +7,7 @@ import akka.http.scaladsl.server.{ Directive0, Directive1, MalformedQueryParamRe
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.util.Tuple
 import akka.http.scaladsl.unmarshalling.{ FromStringUnmarshaller => FSU, Unmarshaller }
+import akka.stream.Materializer
 import scala.util.{ Failure, Success }
 import scala.concurrent.ExecutionContext
 
@@ -31,7 +32,7 @@ object Directives {
    */
   def parameterList(pm: ParametersListMagnet): pm.Out = pm()
 
-  implicit def fromNameReceptacle[T](nr: NameReceptacle[T])(implicit fsu: FSU[T], ec: ExecutionContext) =
+  implicit def fromNameReceptacle[T](nr: NameReceptacle[T])(implicit fsu: FSU[T], materializer: Materializer, ec: ExecutionContext) =
     new ParametersListMagnet {
       type Out = Directive1[List[T]]
       def apply() =


### PR DESCRIPTION
 Migrate to Akka Streams and HTTP 2.0-M2

- Implement necessary modification to support Akka Streams and HTTP 2.0-M2
- Remove support for Java 6