### PR TITLE
Upgrade akka streams and http to 2.0.3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,8 +2,8 @@ import sbt._
 
 object Version {
   val akka       = "2.3.12"
-  val akkaHttp   = "2.0.1"
-  val akkaStream = "2.0.1"
+  val akkaHttp   = "2.0.3"
+  val akkaStream = "2.0.3"
   val mockito    = "1.9.5"
   val scala      = "2.11.7"
   val scalaTest  = "2.2.4"


### PR DESCRIPTION
As part of upgrade ensure stdin, stdout, and stderr streams are being
executed with the same dispatcher as BlockingProcess

Default behaviour of Akka Streams since 2.0.3 onwards is to setup
i/o and file related streams to use default blocking i/o dispatcher