### PR TITLE
Use the latest Akka

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Version {
-  val akka       = "2.4.2"
+  val akka       = "2.4.4"
   val mockito    = "1.9.5"
   val scala      = "2.11.7"
   val scalaTest  = "2.2.4"


### PR DESCRIPTION
A binary compat changed occurred with Akka 2.4.3 w.r.t. optionalHeaderValueByType