### PR TITLE
Avoid using the BlockingProcess dispatcher for IO

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,0 +1,32 @@
+akka {
+  process {
+    blocking-process {
+      # The configuration key to use in order to override the dispatcher used for blocking IO.
+      blocking-io-dispatcher-id = "akka.process.blocking-process.blocking-io-dispatcher"
+
+      # The default dispatcher to be used for IO operations within the BlockingProcess actor
+      blocking-io-dispatcher {
+        executor = "thread-pool-executor"
+
+        # Controls the number of runnable processes in a node
+        # Each process requires 2 threads to monitor stdout and stderr, and another for stdin if you use it
+        # One additional thread is required by ConductR to run instances of BlockingProcess actor which manage the process
+        thread-pool-executor {
+          # Minimum number of threads within the pool.
+          # Supports running 10 processes at a minimum (i.e. 10 * 2 threads per process + 1 Blocking process running thread)
+          core-pool-size-min    = 30
+          core-pool-size-factor = 1.0
+          core-pool-size-max    = 30
+
+          # Maximum number of threads within the pool.
+          # Supports running 100 processes at a maximum (i.e. 100 * 2 threads per process + 1 Blocking process running thread)
+          # Beware that if you have 300 threads then you'll consume about 300MiB of native heap in stack space.
+          max-pool-size-min    = 300
+          max-pool-size-factor = 1.0
+          max-pool-size-max    = 300
+        }
+      }
+
+    }
+  }
+}


### PR DESCRIPTION
The BlockingProcess actor's dispatcher was leveraged for use by various IO operations within it. For some undiscovered reason, this led the BlockingProcess to become blocked at around the minimum number of threads per the core setting of its ThreadPoolExecutor (21).

I was able to create a new test that started up 100 processes, and therefore 300 threads on a dedicated dispatcher. Without the changes to the BlockingProcess actor i.e. with the actor sharing its TPE with the stdio stream sources and sinks, the test often failed and hung. With the changes where the TPE is dedicated to the IO, and the BlockingProcess actor resides on the default dispatcher, I was unable to reproduce the issue.

In addition, having a dispatcher dedicated to the actor's IO feels correct from a design standpoint.

Finally, the problem of seeing that threads were blocked in the manner described here was observed at a ConductR customer's site. ConductR uses the BlockingProcess actor to manage its bundle processes. By applying these changes I'm optimistic that the customer issue will be resolved.