### PR TITLE
Introduce Akka Distributed Data helper classes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ libraryDependencies ++= List(
   Library.akkaCluster,
   Library.akkaStream,
   Library.akkaHttp,
+  Library.akkaDistributedData,
   Library.akkaTestkit     % "test",
   Library.akkaHttpTestkit % "test",
   Library.mockitoAll      % "test",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Version {
-  val akka       = "2.4.7"
+  val akka       = "2.4.10"
   val mockito    = "1.9.5"
   val scala      = "2.11.8"
   val scalaTest  = "2.2.6"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,11 +8,12 @@ object Version {
 }
 
 object Library {
-  val akkaCluster     = "com.typesafe.akka" %% "akka-cluster"           % Version.akka
-  val akkaHttp        = "com.typesafe.akka" %% "akka-http-experimental" % Version.akka
-  val akkaStream      = "com.typesafe.akka" %% "akka-stream"            % Version.akka
-  val akkaTestkit     = "com.typesafe.akka" %% "akka-testkit"           % Version.akka
-  val akkaHttpTestkit = "com.typesafe.akka" %% "akka-http-testkit"      % Version.akka
-  val mockitoAll      = "org.mockito"       %  "mockito-all"            % Version.mockito
-  val scalaTest       = "org.scalatest"     %% "scalatest"              % Version.scalaTest
+  val akkaCluster           = "com.typesafe.akka" %% "akka-cluster"                       % Version.akka
+  val akkaHttp              = "com.typesafe.akka" %% "akka-http-experimental"             % Version.akka
+  val akkaStream            = "com.typesafe.akka" %% "akka-stream"                        % Version.akka
+  val akkaDistributedData   = "com.typesafe.akka" %% "akka-distributed-data-experimental" % Version.akka
+  val akkaTestkit           = "com.typesafe.akka" %% "akka-testkit"                       % Version.akka
+  val akkaHttpTestkit       = "com.typesafe.akka" %% "akka-http-testkit"                  % Version.akka
+  val mockitoAll            = "org.mockito"       %  "mockito-all"                        % Version.mockito
+  val scalaTest             = "org.scalatest"     %% "scalatest"                          % Version.scalaTest
 }

--- a/src/main/scala/akka/contrib/actor/EmptyActor.scala
+++ b/src/main/scala/akka/contrib/actor/EmptyActor.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2014-2016 Typesafe, Inc. All rights reserved.
+ * No information contained herein may be reproduced or transmitted in any form
+ * or by any means without the express written permission of Typesafe, Inc.
+ */
+
+package akka.contrib.actor
+
+import akka.actor.Actor
+import akka.actor.Actor.emptyBehavior
+
+/**
+ * An empty actor is just that - it does nothing, but can be useful for those
+ * actors where you wish to apply stack-able traits and thus use this in place
+ * of your Actor extending just Actor.
+ */
+abstract class EmptyActor extends Actor {
+  override def receive: Receive =
+    emptyBehavior
+}

--- a/src/main/scala/akka/contrib/cluster/ddata/ORMapState.scala
+++ b/src/main/scala/akka/contrib/cluster/ddata/ORMapState.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2014-2016 Typesafe, Inc. All rights reserved.
+ * No information contained herein may be reproduced or transmitted in any form
+ * or by any means without the express written permission of Typesafe, Inc.
+ */
+
+package akka.contrib.cluster.ddata
+
+import akka.cluster.ddata.{ ORMap, ReplicatedData }
+
+/**
+ * Useful helper methods for ORMap - particularly around managing change.
+ */
+object ORMapState {
+  def changed[A <: ReplicatedData](
+    oldData: Option[ORMap[A]],
+    newData: Option[ORMap[A]],
+    valueAdded: (String, A) => Unit,
+    valueRemoved: (String, A) => Unit,
+    valueChanged: (String, A, A) => Unit): Unit =
+    (oldData, newData) match {
+      case (Some(oldMaps: ORMap[A]), Some(newMaps: ORMap[A])) =>
+        for ((key, oldValue) <- oldMaps.entries)
+          newMaps.entries.get(key) match {
+            case Some(newValue) if newValue != oldValue => valueChanged(key, oldValue, newValue)
+            case Some(newValue)                         =>
+            case None                                   => valueRemoved(key, oldValue)
+          }
+        for ((key, newValue) <- newMaps.entries if !oldMaps.entries.contains(key))
+          valueAdded(key, newValue)
+
+      case (None, Some(newMaps: ORMap[A])) =>
+        for ((key, newValue) <- newMaps.entries)
+          valueAdded(key, newValue)
+
+      case (Some(oldMaps: ORMap[A]), None) =>
+        for ((key, oldValue) <- oldMaps.entries)
+          valueRemoved(key, oldValue)
+
+      case _ => // We don't care about (None, None)
+    }
+
+  def getValue[A <: ReplicatedData](data: Option[ORMap[A]], key: String): Option[A] =
+    get(data).get(key)
+
+  def get[A <: ReplicatedData](data: Option[ORMap[A]]): ORMap[A] =
+    data.getOrElse(ORMap.empty[A])
+}

--- a/src/main/scala/akka/contrib/cluster/ddata/ORMultiMapState.scala
+++ b/src/main/scala/akka/contrib/cluster/ddata/ORMultiMapState.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2014-2016 Typesafe, Inc. All rights reserved.
+ * No information contained herein may be reproduced or transmitted in any form
+ * or by any means without the express written permission of Typesafe, Inc.
+ */
+
+package akka.contrib.cluster.ddata
+
+import akka.cluster.ddata.ORMultiMap
+
+import scala.collection.breakOut
+
+/**
+ * Useful helper methods for ORMultiMap - particularly around managing change.
+ */
+object ORMultiMapState {
+
+  def noop[A](a: A) = ()
+
+  /**
+   * Discern what has changed in the data and call back as appropriate.
+   */
+  def changed[A](
+    oldData: Option[ORMultiMap[A]],
+    newData: Option[ORMultiMap[A]],
+    bindingAdded: (String, A) => Unit,
+    bindingRemoved: (String, A) => Unit,
+    bindingChanged: (String, A, A) => Unit,
+    distance: (A, A) => Option[Int] = (_: A, _: A) => None): Unit =
+    (oldData, newData) match {
+      case (Some(oldData: ORMultiMap[A]), Some(newData: ORMultiMap[A])) =>
+        def bindings(data: ORMultiMap[A]) =
+          data.entries.flatMap { case (k, vs) => vs.map(k -> _) }(breakOut): Set[(String, A)]
+        def combinations[AC, BC](as: Set[AC], bs: Set[BC]) =
+          for (a <- as; b <- bs) yield a -> b
+        val oldBindings = bindings(oldData)
+        val newBindings = bindings(newData)
+        val equalBindings = oldBindings.intersect(newBindings)
+        val changedBindings = combinations(oldBindings -- equalBindings, newBindings -- equalBindings)
+          .collect {
+            case ((k1, v1), (k2, v2)) if k1 == k2 && distance(v1, v2).isDefined =>
+              k1 -> ((v1, v2) -> math.abs(distance(v1, v2).get))
+          }
+          .groupBy(_._1)
+          .values
+          .flatMap(bs => (Set.empty[(String, (A, A))] /: bs.toList.sortBy(_._2._2)) {
+            case (acc, (k, ((v1, v2), _))) =>
+              if (acc.forall { case (_, (vv1, vv2)) => vv1 != v1 && vv2 != v2 }) acc + (k -> (v1, v2)) else acc
+          })
+        for ((k, v) <- oldBindings.diff(newBindings) -- changedBindings.map { case (k, (v, _)) => k -> v })
+          bindingRemoved(k, v)
+        for ((k, v) <- newBindings.diff(oldBindings) -- changedBindings.map { case (k, (_, v)) => k -> v })
+          bindingAdded(k, v)
+        for ((k, (v1, v2)) <- changedBindings)
+          bindingChanged(k, v1, v2)
+
+      case (None, Some(newData: ORMultiMap[A])) =>
+        for {
+          (key, newBindings) <- newData.entries
+          element <- newBindings
+        } bindingAdded(key, element)
+
+      case (Some(oldData: ORMultiMap[A]), None) =>
+        for {
+          (key, oldBindings) <- oldData.entries
+          element <- oldBindings
+        } bindingRemoved(key, element)
+
+      case _ => // We don't care about (None, None)
+    }
+
+  /**
+   * Return bindings for a given key.
+   */
+  def collectBindings[A](data: Option[ORMultiMap[A]], key: String): Set[A] =
+    getOrEmpty(data).get(key).getOrElse(Set.empty)
+
+  /**
+   * Upwarp the given optional `ORMultiMap` or return an empty one.
+   */
+  def getOrEmpty[A](data: Option[ORMultiMap[A]]): ORMultiMap[A] =
+    data.getOrElse(ORMultiMap.empty[A])
+}

--- a/src/main/scala/akka/contrib/cluster/ddata/ORSetState.scala
+++ b/src/main/scala/akka/contrib/cluster/ddata/ORSetState.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2014-2016 Typesafe, Inc. All rights reserved.
+ * No information contained herein may be reproduced or transmitted in any form
+ * or by any means without the express written permission of Typesafe, Inc.
+ */
+
+package akka.contrib.cluster.ddata
+
+import akka.cluster.ddata.{ ORSet, ReplicatedData }
+
+/**
+ * Useful helper methods for ORSet - particularly around managing change.
+ */
+object ORSetState {
+  def changed[A <: ReplicatedData](
+    oldData: Option[ORSet[A]],
+    newData: Option[ORSet[A]],
+    valueAdded: A => Unit,
+    valueRemoved: A => Unit): Unit =
+    (oldData, newData) match {
+      case (Some(oldSets: ORSet[A]), Some(newSets: ORSet[A])) =>
+        for (oldValue <- oldSets.elements)
+          if (!newSets.elements.contains(oldValue))
+            valueRemoved(oldValue)
+        for ((newValue) <- newSets.elements if !oldSets.elements.contains(newValue))
+          valueAdded(newValue)
+
+      case (None, Some(newSets: ORSet[A])) =>
+        for (newValue <- newSets.elements)
+          valueAdded(newValue)
+
+      case (Some(oldSets: ORSet[A]), None) =>
+        for (oldValue <- oldSets.elements)
+          valueRemoved(oldValue)
+
+      case _ => // We don't care about (None, None)
+    }
+}

--- a/src/main/scala/akka/contrib/cluster/ddata/ReplicatingActor.scala
+++ b/src/main/scala/akka/contrib/cluster/ddata/ReplicatingActor.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2014-2016 Typesafe, Inc. All rights reserved.
+ * No information contained herein may be reproduced or transmitted in any form
+ * or by any means without the express written permission of Typesafe, Inc.
+ */
+
+package akka.contrib.cluster.ddata
+
+import akka.actor.ActorRef
+import akka.cluster.ddata.DistributedData
+import akka.contrib.actor.EmptyActor
+
+/**
+ * Base behavior for any actor that is to handle replicated state. To be used in conjunction with any of the
+ * stack-able actors e.g. BundleExecutionState, BundleInfoState etc. Concrete implementers should ensure
+ * that super.receive is called so that the stack-able traits can handle their related events.
+ */
+abstract class ReplicatingActor extends EmptyActor {
+  protected final val replicator: ActorRef =
+    DistributedData(context.system).replicator
+}

--- a/src/test/scala/akka/contrib/cluster/ddata/ORMapStateSpec.scala
+++ b/src/test/scala/akka/contrib/cluster/ddata/ORMapStateSpec.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2014-2016 Typesafe, Inc. All rights reserved.
+ * No information contained herein may be reproduced or transmitted in any form
+ * or by any means without the express written permission of Typesafe, Inc.
+ */
+
+package akka.contrib.cluster.ddata
+
+import akka.cluster.ddata.{ ORMap, ReplicatedData }
+
+object ORMapStateSpec {
+  case class Data(v: String) extends ReplicatedData {
+    override type T = this.type
+    override def merge(that: Data.this.type): Data.this.type =
+      that
+  }
+}
+
+class ORMapStateSpec extends StateSpec {
+
+  import ORMapStateSpec._
+
+  "ORMapState" should {
+
+    "signal that an element is added with no previous data" in {
+      val entry = Some(ORMap.empty[Data] + ("foo" -> Data("bar")))
+      def added(key: String, value: Data): Unit = {
+        key shouldBe "foo"
+        value shouldBe Data("bar")
+      }
+      def removed(key: String, value: Data): Unit = {
+        fail("Shouldn't be removed")
+      }
+      def changed(key: String, oldValue: Data, newValue: Data): Unit = {
+        fail("Shouldn't be changed")
+      }
+      ORMapState.changed(None, entry, added, removed, changed)
+    }
+
+    "signal that an element is added with some previous empty data" in {
+      val entry = Some(ORMap.empty[Data] + ("foo" -> Data("bar")))
+      def added(key: String, value: Data): Unit = {
+        key shouldBe "foo"
+        value shouldBe Data("bar")
+      }
+      def removed(key: String, value: Data): Unit = {
+        fail("Shouldn't be removed")
+      }
+      def changed(key: String, oldValue: Data, newValue: Data): Unit = {
+        fail("Shouldn't be changed")
+      }
+      ORMapState.changed(Some(ORMap.empty[Data]), entry, added, removed, changed)
+    }
+
+    "signal that an element is removed and then added with some previous changed data" in {
+      val oldEntry = Some(ORMap.empty[Data] + ("foo" -> Data("bar1")))
+      val newEntry = Some(ORMap.empty[Data] + ("foo" -> Data("bar2")))
+      def added(key: String, value: Data): Unit = {
+        fail("Shouldn't be added")
+      }
+      def removed(key: String, value: Data): Unit = {
+        fail("Shouldn't be removed")
+      }
+      def changed(key: String, oldValue: Data, newValue: Data): Unit = {
+        oldValue shouldBe Data("bar1")
+        newValue shouldBe Data("bar2")
+      }
+      ORMapState.changed(oldEntry, newEntry, added, removed, changed)
+    }
+
+    "not signal that an element is added with the same previous data" in {
+      val entry = Some(ORMap.empty[Data] + ("foo" -> Data("bar")))
+      def added(key: String, value: Data): Unit = {
+        fail("Shouldn't be added")
+
+      }
+      def removed(key: String, value: Data): Unit = {
+        fail("Shouldn't be removed")
+      }
+      def changed(key: String, oldValue: Data, newValue: Data): Unit = {
+        fail("Shouldn't be changed")
+      }
+      ORMapState.changed(entry, entry, added, removed, changed)
+    }
+
+    "signal that an element is removed with some previous data" in {
+      val entry = Some(ORMap.empty[Data] + ("foo" -> Data("bar")))
+      def added(key: String, value: Data): Unit = {
+        fail("Shouldn't be added")
+      }
+      def removed(key: String, value: Data): Unit = {
+        key shouldBe "foo"
+        value shouldBe Data("bar")
+      }
+      def changed(key: String, oldValue: Data, newValue: Data): Unit = {
+        fail("Shouldn't be changed")
+      }
+      ORMapState.changed(entry, Some(ORMap.empty[Data]), added, removed, changed)
+    }
+  }
+}

--- a/src/test/scala/akka/contrib/cluster/ddata/ORMultiMapStateSpec.scala
+++ b/src/test/scala/akka/contrib/cluster/ddata/ORMultiMapStateSpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2014-2016 Typesafe, Inc. All rights reserved.
+ * No information contained herein may be reproduced or transmitted in any form
+ * or by any means without the express written permission of Typesafe, Inc.
+ */
+
+package akka.contrib.cluster.ddata
+
+import akka.cluster.ddata.ORMultiMap
+
+class ORMultiMapStateSpec extends StateSpec {
+
+  "ORMultiMapState" should {
+    "discern a change for where there is no existing binding, but a new element" in {
+      val newData = ORMultiMap.empty[String].addBinding("a", "1")
+
+      var bindingsAdded = Set.empty[String]
+      def added(key: String, value: Any) = bindingsAdded += value.toString
+      def removed(key: String, value: Any) = fail("Shouldn't be removed")
+      def changed(key: String, oldValue: Any, newValue: Any) = fail("Shouldn't be changed")
+      ORMultiMapState.changed(None, Some(newData), added, removed, changed)
+
+      bindingsAdded shouldBe Set("1")
+    }
+
+    "discern a change for where there is an existing binding, but a new element" in {
+      val oldData = ORMultiMap.empty[String].addBinding("a", "1")
+      val newData = ORMultiMap.empty[String].addBinding("a", "1").addBinding("a", "2")
+
+      var bindingsAdded = Set.empty[String]
+      def added(key: String, value: String) = bindingsAdded += value
+      def removed(key: String, value: String) = fail("Shouldn't be removed")
+      def changed(key: String, oldValue: String, newValue: String) = fail("Shouldn't be changed")
+      ORMultiMapState.changed(Some(oldData), Some(newData), added, removed, changed)
+
+      bindingsAdded shouldBe Set("2")
+    }
+
+    "do the right thing for a complex change" in {
+      val oldData = ORMultiMap.empty[Int]
+        .addBinding("a", 1)
+        .addBinding("a", 2)
+        .addBinding("a", 3)
+        .addBinding("b", 1)
+        .addBinding("b", 2)
+        .addBinding("b", 3)
+      val newData = ORMultiMap.empty[Int]
+        .addBinding("a", 1)
+        .addBinding("a", 3)
+        .addBinding("a", 4)
+        .addBinding("a", 5)
+        .addBinding("b", 2)
+        .addBinding("b", 4)
+      var bindingsAdded = Set.empty[(String, Int)]
+      var bindingsRemoved = Set.empty[(String, Int)]
+      var bindingsChanged = Set.empty[(String, Int, Int)]
+      ORMultiMapState.changed(
+        Some(oldData),
+        Some(newData),
+        (k, v: Int) => bindingsAdded += k -> v,
+        (k, v: Int) => bindingsRemoved += k -> v,
+        (k, v1: Int, v2: Int) => bindingsChanged += ((k, v1, v2)), // Damn auto-tupling!
+        (v1: Int, v2: Int) => Some(v1 - v2)
+      )
+      bindingsAdded shouldBe Set("a" -> 5)
+      bindingsRemoved shouldBe Set("b" -> 1)
+      bindingsChanged shouldBe Set(("a", 2, 4), ("b", 3, 4))
+    }
+  }
+}

--- a/src/test/scala/akka/contrib/cluster/ddata/ORSetStateSpec.scala
+++ b/src/test/scala/akka/contrib/cluster/ddata/ORSetStateSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2014-2016 Typesafe, Inc. All rights reserved.
+ * No information contained herein may be reproduced or transmitted in any form
+ * or by any means without the express written permission of Typesafe, Inc.
+ */
+
+package akka.contrib.cluster.ddata
+
+import akka.cluster.ddata.{ ORSet, ReplicatedData }
+
+object ORSetStateSpec {
+  case class Data(v: String) extends ReplicatedData {
+    override type T = this.type
+    override def merge(that: Data.this.type): Data.this.type =
+      that
+  }
+}
+
+class ORSetStateSpec extends StateSpec {
+  import ORSetStateSpec._
+
+  "ORSetState" should {
+
+    "signal that an element is added with no previous data" in {
+      val entry = Some(ORSet.empty[Data] + Data("bar"))
+      def added(value: Data): Unit =
+        value shouldBe Data("bar")
+      def removed(value: Data): Unit =
+        fail("Shouldn't be removed")
+      ORSetState.changed(None, entry, added, removed)
+    }
+
+    "signal that an element is added with some previous empty data" in {
+      val entry = Some(ORSet.empty[Data] + Data("bar"))
+      def added(value: Data): Unit =
+        value shouldBe Data("bar")
+      def removed(value: Data): Unit =
+        fail("Shouldn't be removed")
+      ORSetState.changed(Some(ORSet.empty[Data]), entry, added, removed)
+    }
+
+    "not signal that an element is added with the same previous data" in {
+      val entry = Some(ORSet.empty[Data] + Data("bar"))
+      def added(value: Data): Unit =
+        fail("Shouldn't be added")
+      def removed(value: Data): Unit =
+        fail("Shouldn't be removed")
+      ORSetState.changed(entry, entry, added, removed)
+    }
+
+    "signal that an element is removed with some previous data" in {
+      val entry = Some(ORSet.empty[Data] + Data("bar"))
+      def added(value: Data): Unit =
+        fail("Shouldn't be added")
+      def removed(value: Data): Unit =
+        value shouldBe Data("bar")
+      ORSetState.changed(entry, Some(ORSet.empty[Data]), added, removed)
+    }
+  }
+}

--- a/src/test/scala/akka/contrib/cluster/ddata/StateSpec.scala
+++ b/src/test/scala/akka/contrib/cluster/ddata/StateSpec.scala
@@ -1,0 +1,43 @@
+package akka.contrib.cluster.ddata
+
+import akka.actor.ActorSystem
+import akka.cluster.Cluster
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+trait StateSpec extends WordSpec with Matchers with BeforeAndAfterAll {
+  protected implicit val testConfig = ConfigFactory.parseString(
+    """|akka {
+       |  actor {
+       |    provider = akka.cluster.ClusterActorRefProvider
+       |  }
+       |
+       |  loggers = ["akka.testkit.TestEventListener"]
+       |
+       |  loglevel = debug
+       |
+       |  remote {
+       |    enabled-transports          = [akka.remote.netty.tcp]
+       |    log-remote-lifecycle-events = off
+       |
+       |    netty.tcp {
+       |      hostname = "127.0.0.1"
+       |      port     = 0
+       |    }
+       |  }
+       |
+       |  log-dead-letters                 = on
+       |  log-dead-letters-during-shutdown = on
+       |}
+       |""".stripMargin
+  )
+  protected implicit val system = ActorSystem(this.getClass.getSimpleName, testConfig)
+  protected implicit val cluster = Cluster.get(system)
+
+  override protected def afterAll(): Unit = {
+    Await.ready(system.terminate(), Duration.Inf)
+  }
+}

--- a/src/test/scala/akka/contrib/process/BlockingProcessSpec.scala
+++ b/src/test/scala/akka/contrib/process/BlockingProcessSpec.scala
@@ -14,7 +14,7 @@ import java.io.File
 import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
 import scala.collection.immutable
 import scala.concurrent.Await
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.{ Duration, DurationInt }
 
 class BlockingProcessSpec extends WordSpec with Matchers with BeforeAndAfterAll {
 
@@ -81,8 +81,7 @@ class BlockingProcessSpec extends WordSpec with Matchers with BeforeAndAfterAll 
   }
 
   override protected def afterAll(): Unit = {
-    system.shutdown()
-    system.awaitTermination()
+    Await.ready(system.terminate(), Duration.Inf)
   }
 
   def expectDestruction(viaDestroy: Boolean): Unit = {


### PR DESCRIPTION
Introduce helpers for Akka Distributed Data
- Introduce `ReplicatingActor` to provide stackable base behaviour to handle replicated state.
- Introduce `ORMapState`, `ORMultiMapState`, and `ORSetState` to help manage changes within `ORMap`, `ORMultiMap`, and `ORSet` respectively.

Also:
- Upgrade Akka to 2.4.10
- Introduce EmptyActor to help with applying stackable traits
