### PR TITLE
BlockingProcess modified to poll isAlive() to determine if a process has exited.

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -27,6 +27,8 @@ akka {
         }
       }
 
+      # The process will be inspected at this interval to ensure it is still alive.
+      inspection-interval = 1 second
     }
   }
 }

--- a/src/test/resources/loop.sh
+++ b/src/test/resources/loop.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+logger my pid is $$
+
+trap 'logger killing $$; kill -9 $$' SIGTERM
+
+1>&2 sleep 8 &
+wait


### PR DESCRIPTION
This PR modifies `BlockingProcess` in a few ways:

Periodically we check `Process.isAlive()` via sending `Inspect` to `ProcessDestroyer`. Prior to this, we would only be notified if a process exited if its stdout and stderr file descriptors had exited. This is incorrect since these descriptors can live on beyond the execution of a process (via forking).

`Destroy` and `DestroyForcibly` now result in calls to `Process.destroy()` or `Process.destroyForcibly()`, respectively delivering a `SIGTERM` or `SIGKILL`, on UNIX at least - https://github.com/frohoff/jdk8u-jdk/blob/da0da73ab82ed714

When `stdout` or `stderr` exit, we fire an `Inspect` which allows us to exit in a quick manner in the ideal case, without having to wait for the next poll.

I think this is a quite safe implementation, and a big improvement over what was here before. Note that the tests didn't have to change, and only one additional test was added (which previously failed).