### PR TITLE
Fix Blocking Dispatcher's configuration - Fixes #58

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -12,18 +12,10 @@ akka {
         # Each process requires 2 threads to monitor stdout and stderr, and another for stdin if you use it
         # One additional thread is required by ConductR to run instances of BlockingProcess actor which manage the process
         thread-pool-executor {
-          # Minimum number of threads within the pool.
-          # Supports running 10 processes at a minimum (i.e. 10 * 2 threads per process + 1 Blocking process running thread)
-          core-pool-size-min    = 30
-          core-pool-size-factor = 1.0
-          core-pool-size-max    = 30
-
-          # Maximum number of threads within the pool.
-          # Supports running 100 processes at a maximum (i.e. 100 * 2 threads per process + 1 Blocking process running thread)
-          # Beware that if you have 300 threads then you'll consume about 300MiB of native heap in stack space.
-          max-pool-size-min    = 300
-          max-pool-size-factor = 1.0
-          max-pool-size-max    = 300
+          # The number of threads within the pool.
+          # Supports running 50 processes at a maximum (i.e. (102 / 2 threads per process) - 1)
+          # Given 102 threads if a JVM process is started with a 256k stack you'll consume about 25MiB of native heap in stack space.
+          fixed-pool-size = 102
         }
       }
 


### PR DESCRIPTION
Use a fixed pool size to support 50 processes at maximum.

The 50 processes number is selected as it will consume `~25MiB` of heap.