### PR TITLE
upgrade to much newer sbt-bintray version

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,10 +1,9 @@
-import bintray.Plugin.bintrayPublishSettings
-import bintray.Keys._
 import com.typesafe.sbt.SbtScalariform._
 import sbt._
 import sbt.Keys._
 import sbtrelease.ReleasePlugin._
 import scalariform.formatter.preferences._
+import bintray.BintrayKeys._
 
 object Build extends AutoPlugin {
 
@@ -17,7 +16,6 @@ object Build extends AutoPlugin {
   override def projectSettings =
     scalariformSettings ++
     releaseSettings ++
-    bintrayPublishSettings ++
     List(
       // Core settings
       organization := "com.typesafe.akka",
@@ -42,7 +40,7 @@ object Build extends AutoPlugin {
       // Release settings
       ReleaseKeys.versionBump := sbtrelease.Version.Bump.Minor,
       // Bintray settings
-      bintrayOrganization in bintray := Some("typesafe"),
-      repository in bintray := "maven-releases"
+      bintrayOrganization := Some("typesafe"),
+      bintrayRepository := "maven-releases"
     )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.15
+sbt.version = 0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.github.gseitz" % "sbt-release"     % "0.8.5")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-scalariform" % "1.3.0")
-addSbtPlugin("me.lessis"         % "bintray-sbt"     % "0.2.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray"     % "0.5.1")


### PR DESCRIPTION
this will make it easier to keep this repo in the Scala
community build, since the newer sbt-bintray version is
dbuild-compatible

the sbt version bump also helps ensure community build friendliness