### PR TITLE
Close process stdin when the stream completes 

### DIFF
--- a/src/main/scala/akka/contrib/process/NonBlockingProcess.scala
+++ b/src/main/scala/akka/contrib/process/NonBlockingProcess.scala
@@ -181,6 +181,10 @@ class NonBlockingProcess(
         val stdin =
           Sink
             .foreach[ByteString](bytes => nuProcess.writeStdin(bytes.toByteBuffer))
+            .mapMaterializedValue { future =>
+              future.onComplete(_ => nuProcess.closeStdin(false))
+              future
+            }
         val (out, stdout) =
           Source
             .queue[ByteString](stdoutBufferMaxChunks, OverflowStrategy.dropHead)


### PR DESCRIPTION
Firstly, thanks for the NonBlockingProcess actor - this is exactly what I was looking for. Realize it's pretty bleeding edge but I'd love to help getting it stable.

The process I was trying to wrap takes input on stdin, and waits for EOF before outputting to stdout and terminiating - but using the actor the process was hanging because stdin wasn't being closed.

I found the NuProcess.closeStdin API, and sure enough hooking that into the Sink completion did the trick.