### PR TITLE
Allow inspectionTick cancelling in overridden postStop method for NonBlockingProcess sub-classes

### DIFF
--- a/src/main/scala/akka/contrib/process/NonBlockingProcess.scala
+++ b/src/main/scala/akka/contrib/process/NonBlockingProcess.scala
@@ -4,7 +4,7 @@
 
 package akka.contrib.process
 
-import akka.actor.{ Actor, ActorLogging, NoSerializationVerificationNeeded, Props }
+import akka.actor.{ Actor, ActorLogging, Cancellable, NoSerializationVerificationNeeded, Props }
 import akka.stream.scaladsl.{ BroadcastHub, FileIO, Keep, Sink, Source, SourceQueueWithComplete }
 import akka.util.ByteString
 import java.nio.ByteBuffer
@@ -152,7 +152,7 @@ class NonBlockingProcess(
       TimeUnit.MILLISECONDS
     )
 
-  private val inspectionTick =
+  protected val inspectionTick: Cancellable =
     context.system.scheduler.schedule(inspectionInterval, inspectionInterval, self, Inspect)
 
   private val contextMat = ActorMaterializer()


### PR DESCRIPTION
I'd like to be able to override the <code>postStop</code> method of <code>NonBlockingProcess</code> actor (in particular, to change the method of the process destruction or something like that, so I don't want to call the <code>super.postStop</code> in my new sub-class) and have the ability to cancel the <code>inspectionTick</code> Cancellable (since it's private for now). Therefore, I propose to make this val <code>protected</code>.